### PR TITLE
feat: Discord OAuth2 로그인, 로그아웃

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+
+    // OAuth2 login
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/nativekoreankoala/demo/config/SecurityConfig.java
+++ b/src/main/java/nativekoreankoala/demo/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package nativekoreankoala.demo.config;
+
+import lombok.RequiredArgsConstructor;
+import nativekoreankoala.demo.service.CustomOAuth2UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/auth/discord").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .loginPage("/auth/discord")
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .defaultSuccessUrl("/", true) // 프론트 url
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/nativekoreankoala/demo/config/SecurityConfig.java
+++ b/src/main/java/nativekoreankoala/demo/config/SecurityConfig.java
@@ -28,6 +28,12 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService)
                         )
                         .defaultSuccessUrl("/", true) // 프론트 url
+                )
+                .logout(logout -> logout
+                        .logoutSuccessUrl("/auth/discord")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                        .deleteCookies("JSESSIONID")
                 );
 
         return http.build();

--- a/src/main/java/nativekoreankoala/demo/controller/AuthController.java
+++ b/src/main/java/nativekoreankoala/demo/controller/AuthController.java
@@ -1,0 +1,18 @@
+package nativekoreankoala.demo.controller;
+
+import lombok.RequiredArgsConstructor;
+import nativekoreankoala.demo.service.UserService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @GetMapping("/auth/discord")
+    public String discordLogin() {
+        return "redirect:/oauth2/authorization/discord";
+    }
+}

--- a/src/main/java/nativekoreankoala/demo/entity/User.java
+++ b/src/main/java/nativekoreankoala/demo/entity/User.java
@@ -1,0 +1,47 @@
+package nativekoreankoala.demo.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String discordId;
+
+    private String username;
+    private String email;
+    private String avatar;
+    private String discriminator;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime lastLoginAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        lastLoginAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        lastLoginAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/nativekoreankoala/demo/repository/UserRepository.java
+++ b/src/main/java/nativekoreankoala/demo/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package nativekoreankoala.demo.repository;
+
+import nativekoreankoala.demo.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByDiscordId(String discordId);
+}

--- a/src/main/java/nativekoreankoala/demo/service/CustomOAuth2UserService.java
+++ b/src/main/java/nativekoreankoala/demo/service/CustomOAuth2UserService.java
@@ -1,0 +1,33 @@
+package nativekoreankoala.demo.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nativekoreankoala.demo.entity.User;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String discordId = oAuth2User.getAttribute("id");
+        String username = oAuth2User.getAttribute("username");
+        String email = oAuth2User.getAttribute("email");
+        String avatar = oAuth2User.getAttribute("avatar");
+        String discriminator = oAuth2User.getAttribute("discriminator");
+
+        User user = userService.saveOrUpdateUser(discordId, username, email, avatar, discriminator);
+
+        return oAuth2User;
+    }
+}

--- a/src/main/java/nativekoreankoala/demo/service/UserService.java
+++ b/src/main/java/nativekoreankoala/demo/service/UserService.java
@@ -1,0 +1,43 @@
+package nativekoreankoala.demo.service;
+
+import lombok.RequiredArgsConstructor;
+import nativekoreankoala.demo.entity.User;
+import nativekoreankoala.demo.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User saveOrUpdateUser(String discordId, String username, String email, String avatar, String discriminator) {
+        return userRepository.findByDiscordId(discordId)
+                .map(existingUser -> {
+                    existingUser.setUsername(username);
+                    existingUser.setEmail(email);
+                    existingUser.setAvatar(avatar);
+                    existingUser.setDiscriminator(discriminator);
+                    existingUser.setLastLoginAt(LocalDateTime.now());
+                    return userRepository.save(existingUser);
+                })
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .discordId(discordId)
+                            .username(username)
+                            .email(email)
+                            .avatar(avatar)
+                            .discriminator(discriminator)
+                            .build();
+                    return userRepository.save(newUser);
+                });
+    }
+
+    public User getUserByDiscordId(String discordId) {
+        return userRepository.findByDiscordId(discordId).orElse(null);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:koordidb}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+  security:
+    oauth2:
+      client:
+        registration:
+          discord:
+            client-id: ${DISCORD_CLIENT_ID}
+            client-secret: ${DISCORD_CLIENT_SECRET}
+            client-name: Discord
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - identify
+              - email
+        provider:
+          discord:
+            authorization-uri: https://discord.com/api/oauth2/authorize
+            token-uri: https://discord.com/api/oauth2/token
+            user-info-uri: https://discord.com/api/users/@me
+            user-name-attribute: username


### PR DESCRIPTION
## 📝 변경 사항
Discord OAuth2.0을 이용한 소셜 로그인
로그인 시 사용자 정보가 자동으로 MySQL 데이터베이스에 저장


## 🔗 관련 이슈
Closes #1 

## 🎯 변경 타입
- [ ] 🐛 Bug fix (버그 수정)
- [x] ✨ New feature (새로운 기능)
- [ ] 💥 Breaking change (기존 기능을 깨는 변경)
- [ ] 📝 Documentation (문서 업데이트)
- [ ] 🎨 Style (코드 포맷팅, 세미콜론 누락 등)
- [ ] ♻️ Refactoring (리팩토링)
- [ ] ✅ Test (테스트 추가/수정)
- [ ] 🔧 Chore (빌드, 설정 변경 등)

## 📋 변경 사항 상세
### 추가된 기능
- Discord OAuth2 로그인 추가: [GET] `/auth/discord`


## ✅ 체크리스트
- [ ] 코드가 프로젝트 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 주석을 추가했습니다 (특히 이해하기 어려운 부분)
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 🚀 배포 참고사항
배포 시 주의해야 할 사항이 있다면 작성해주세요:
- 환경 변수 추가: 
```
   DISCORD_CLIENT_ID=your_client_id
   DISCORD_CLIENT_SECRET=your_client_secret
   DB_HOST=your_db_host
   DB_PORT=your_db_port
   DB_NAME=your_db_name
   DB_PASSWORD=your_db_password
```

## 💬 리뷰어에게
리뷰어가 특히 주의깊게 봐주었으면 하는 부분을 작성해주세요.